### PR TITLE
changed the value of variable in generatePassword function

### DIFF
--- a/script.js
+++ b/script.js
@@ -223,7 +223,7 @@ function generateArray() {
 }
 
 function generatePassword() {
-  let passwordGen = 0;
+  let passwordGen = 1;
 
   // The passGenLength variable is not being defined within this function.
   for (let p = 0; p < userInput.passwordLength; p++) {


### PR DESCRIPTION
This PR updates the value of the passwordGen variable to 1 used to determine the length of the final password in the generatePassword function.  It was producing an extra character while set to 0.